### PR TITLE
Have `auth.py` use the Dict type hint from the typing module

### DIFF
--- a/pyapns_client/auth.py
+++ b/pyapns_client/auth.py
@@ -6,7 +6,6 @@
 
 import time
 from typing import Any, Dict, Union
-from httpx import Request
 
 import jwt
 from cryptography.hazmat.backends import default_backend

--- a/pyapns_client/auth.py
+++ b/pyapns_client/auth.py
@@ -5,7 +5,7 @@
 
 
 import time
-from typing import Any, Union
+from typing import Any, Dict, Union
 from httpx import Request
 
 import jwt
@@ -19,7 +19,7 @@ class Auth:
     def __init__(self) -> None:
         raise NotImplementedError
 
-    def __call__(self) -> dict[str, Any]:
+    def __call__(self) -> Dict[str, Any]:
         raise NotImplementedError
 
 
@@ -48,7 +48,7 @@ class TokenBasedAuth(Auth):
         self._auth_token_time = None
         self._auth_token_storage = None
 
-    def __call__(self) -> dict[str, Any]:
+    def __call__(self) -> Dict[str, Any]:
         return {
             "auth": self._authenticate_request,
         }
@@ -95,7 +95,7 @@ class CertificateBasedAuth(Auth):
         self._client_cert_path = client_cert_path
         self._client_cert_passphrase = client_cert_passphrase
 
-    def __call__(self) -> dict[str, Any]:
+    def __call__(self) -> Dict[str, Any]:
         return {
             "cert": (
                 self._client_cert_path,


### PR DESCRIPTION
`auth.py` uses `dict[sr, Any]` which only works in Python 3.9 and above.

Python 3.9 is the first version to support type hinting generics in the standard collections. Since this project's setup.py shows that it is compatible with Python 3.6, we should use the Dict hint from the typing module. 

Note that `notification.py` also uses `typing.Dict`