### PR TITLE
Add payload tests and fix some small bugs

### DIFF
--- a/pyapns_client/notification.py
+++ b/pyapns_client/notification.py
@@ -93,7 +93,12 @@ class _Payload:
     def to_dict(self, alert_body=None):
         d = {"aps": {}}
         if self.alert:
-            d["aps"]["alert"] = self.alert.to_dict(alert_body=alert_body)
+            if isinstance(self.alert, _PayloadAlert):
+                d["aps"]["alert"] = self.alert.to_dict(alert_body=alert_body)
+            elif type(self.alert) == str:
+                d["aps"]["alert"] = self.alert
+            else:
+                raise ValueError("alert must be a string or a _PayloadAlert object")
         d.update(self.custom)
         return d
 

--- a/pyapns_client/notification.py
+++ b/pyapns_client/notification.py
@@ -34,7 +34,6 @@ class IOSPayloadAlert(_PayloadAlert):
         subtitle_loc_args=None,
         loc_key=None,
         loc_args=None,
-        action_loc_key=None,
         launch_image=None,
     ):
         super().__init__(title=title, body=body)
@@ -46,7 +45,6 @@ class IOSPayloadAlert(_PayloadAlert):
         self.subtitle_loc_args = subtitle_loc_args
         self.loc_key = loc_key
         self.loc_args = loc_args
-        self.action_loc_key = action_loc_key
         self.launch_image = launch_image
 
     def to_dict(self, alert_body=None):
@@ -65,8 +63,6 @@ class IOSPayloadAlert(_PayloadAlert):
             d["loc-key"] = self.loc_key
         if self.loc_args:
             d["loc-args"] = self.loc_args
-        if self.action_loc_key:
-            d["action-loc-key"] = self.action_loc_key
         if self.launch_image:
             d["launch-image"] = self.launch_image
         return d

--- a/tests/payload_test.py
+++ b/tests/payload_test.py
@@ -1,0 +1,150 @@
+import pytest
+from pyapns_client import (
+    IOSPayload,
+    IOSPayloadAlert,
+    SafariPayload,
+    SafariPayloadAlert,
+)
+
+
+@pytest.fixture
+def ios_payload_alert():
+    return IOSPayloadAlert(
+        title="title",
+        title_loc_key="title_loc_k",
+        title_loc_args=["title_loc_a"],
+        subtitle="subtitle",
+        subtitle_loc_key="subtitle_loc_k",
+        subtitle_loc_args=["subtitle_loc_a"],
+        body="body",
+        loc_key="body_loc_k",
+        loc_args=["body_loc_a"],
+        launch_image="img",
+    )
+
+
+def test_ios_payload_alert(ios_payload_alert):
+    assert ios_payload_alert.to_dict() == {
+        "title": "title",
+        "title-loc-key": "title_loc_k",
+        "title-loc-args": ["title_loc_a"],
+        "subtitle": "subtitle",
+        "subtitle-loc-key": "subtitle_loc_k",
+        "subtitle-loc-args": ["subtitle_loc_a"],
+        "body": "body",
+        "loc-key": "body_loc_k",
+        "loc-args": ["body_loc_a"],
+        "launch-image": "img",
+    }
+
+
+def test_ios_payload():
+    payload = IOSPayload(
+        alert="my_alert",
+        badge=2,
+        sound="chime",
+        content_available=True,
+        mutable_content=True,
+        category="my_category",
+        custom={"extra": "something"},
+        thread_id="42",
+    )
+    assert payload.to_dict() == {
+        "aps": {
+            "alert": "my_alert",
+            "badge": 2,
+            "sound": "chime",
+            "content-available": 1,
+            "mutable-content": 1,
+            "thread-id": "42",
+            "category": "my_category",
+        },
+        "extra": "something",
+    }
+
+
+def test_ios_payload_with_ios_payload_alert(ios_payload_alert):
+    payload = IOSPayload(
+        alert=ios_payload_alert,
+        badge=2,
+        sound="chime",
+        content_available=True,
+        mutable_content=True,
+        category="my_category",
+        custom={"extra": "something"},
+        thread_id="42",
+    )
+    assert payload.to_dict() == {
+        "aps": {
+            "alert": {
+                "title": "title",
+                "title-loc-key": "title_loc_k",
+                "title-loc-args": ["title_loc_a"],
+                "subtitle": "subtitle",
+                "subtitle-loc-key": "subtitle_loc_k",
+                "subtitle-loc-args": ["subtitle_loc_a"],
+                "body": "body",
+                "loc-key": "body_loc_k",
+                "loc-args": ["body_loc_a"],
+                "launch-image": "img",
+            },
+            "badge": 2,
+            "sound": "chime",
+            "content-available": 1,
+            "mutable-content": 1,
+            "thread-id": "42",
+            "category": "my_category",
+        },
+        "extra": "something",
+    }
+
+
+@pytest.fixture
+def safari_payload_alert():
+    return SafariPayloadAlert(
+        title="title",
+        body="body",
+        action="send",
+    )
+
+
+def test_safari_payload_alert(safari_payload_alert):
+    assert safari_payload_alert.to_dict() == {
+        "title": "title",
+        "body": "body",
+        "action": "send",
+    }
+
+
+def test_safari_payload():
+    payload = SafariPayload(
+        alert="my_alert",
+        # url_args = "args"  # omit this to test default
+        custom={"extra": "something"},
+    )
+    assert payload.to_dict() == {
+        "aps": {
+            "alert": "my_alert",
+            "url-args": [],
+        },
+        "extra": "something",
+    }
+
+
+def test_safari_payload_with_safari_payload_alert(safari_payload_alert):
+    payload = SafariPayload(
+        alert=safari_payload_alert,
+        url_args="args",
+        custom={"extra": "something"},
+    )
+    assert payload.to_dict() == {
+        "aps": {
+            "alert": {
+                "title": "title",
+                "body": "body",
+                "action": "send",
+            },
+            "url-args": "args",
+        },
+        "extra": "something",
+    }


### PR DESCRIPTION
Add payload tests based on those from the APNS2 library.

Dropped the 'action_loc_key' because its not defined in [the spec](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943365).

Allowed for 'alerts' to be bare strings as well as _PayloadAlert objects, but not anything else.